### PR TITLE
fix: sql syntax for mariadb

### DIFF
--- a/SQL/mariadb.initial.sql
+++ b/SQL/mariadb.initial.sql
@@ -7,18 +7,18 @@
  */
 
 CREATE TABLE IF NOT EXISTS auth_tokens (
-    `token` varchar(128) NOT NULL,
+    `token` varchar(128) NOT NULL PRIMARY KEY,
     `expires` datetime NOT NULL,
-    `user_id` int check (`user_id` > 0) NOT NULL,
+    `user_id` int unsigned NOT NULL CHECK(`user_id` > 0),
     `user_name` varchar(128) NOT NULL,
     `user_pass` varchar(128) NOT NULL,
-	`host` varchar(255) NOT NULL
-   ,
-	PRIMARY KEY (`token`),
-	CONSTRAINT `auth_tokens_ibfk_1` FOREIGN KEY (`user_id`)
-	REFERENCES users(`user_id`) ON DELETE CASCADE
-) /*!40000 ENGINE=INNODB */ /*!40101 CHARACTER SET utf8mb4 COLLATE utf8mb4_bin */;
+    `host` varchar(255) NOT NULL,
+    CONSTRAINT `auth_tokens_ibfk_1`
+        FOREIGN KEY (`user_id`)
+        REFERENCES users(`user_id`)
+        ON DELETE CASCADE
+);
 
 CREATE INDEX `user_id_fk_auth_tokens` ON auth_tokens (`user_id`);
 
-REPLACE INTO `system` (`name`, `value`) SELECT ('tx-persistent-login-version', '2020080200');
+REPLACE INTO `system` (`name`, `value`) VALUES ('tx-persistent-login-version', '2020080200');


### PR DESCRIPTION
Hello,
the provided SQL for mariadb does not work for me and my mariadb 10.5.2 server due to various reasons - mismatched data types for foreign keys, wrong syntax, ... . The following changes are fix it, feel free to use them.